### PR TITLE
fix: update Terraform workflow to trigger on main branch instead of N…

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,8 +3,7 @@ name: 'Terraform'
 on:
   push:
     branches:
-      # voltar para main quando tiver pronto
-      - NaoRodarAAction
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small but important change to the Terraform GitHub Actions workflow configuration. The workflow is now set to run on pushes to the `main` branch instead of the temporary `NaoRodarAAction` branch.…aoRodarAAction